### PR TITLE
[root] clarify env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=meta-llama/llama-3-8b-instruct:free
+OPENROUTER_SYSTEM_PROMPT="You are Ruyaa, a professional assistant."

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,90 @@
 # RUYA-C
+
+This repository contains both a command line script and a lightweight web UI
+for chatting with the [OpenRouter](https://openrouter.ai) API. The free Meta
+**Llama 3 8B Instruct** model is used by default and requires an API key.
+
+## Requirements
+
+ - Python 3.11+
+- `pip` for installing dependencies
+
+Run `./setup.sh` to install everything from `requirements.txt`.
+
+Both the CLI and web server rely on the `OPENROUTER_API_KEY` environment
+variable. You can store it in a local `.env` file for convenience. Optional
+`OPENROUTER_MODEL` and `OPENROUTER_SYSTEM_PROMPT` variables allow you to change
+the model and system prompt without editing the code.
+
+## Getting started
+
+1. Obtain an API key from [OpenRouter](https://openrouter.ai).
+2. Export the key in your environment or create a `.env` file. You can also
+   optionally set `OPENROUTER_MODEL` or `OPENROUTER_SYSTEM_PROMPT` here if you
+   want to override the defaults:
+
+   ```bash
+   export OPENROUTER_API_KEY="your_api_key_here"
+   export OPENROUTER_MODEL="meta-llama/llama-3-8b-instruct:free"
+   export OPENROUTER_SYSTEM_PROMPT="You are Ruyaa, a professional assistant."
+   ```
+
+   or
+
+   ```bash
+   cat <<EOF > .env
+   OPENROUTER_API_KEY=your_api_key_here
+   OPENROUTER_MODEL=meta-llama/llama-3-8b-instruct:free
+   OPENROUTER_SYSTEM_PROMPT="You are Ruyaa, a professional assistant."
+   EOF
+   ```
+
+3. Run `./setup.sh` once to install dependencies.
+4. Run the chat script:
+
+   ```bash
+   python openrouter_chat.py "Hello, AI!"
+   ```
+
+The script sends your message to OpenRouter and prints the model's reply.
+
+## Web interface
+
+To try a simple web chat UI locally, start the Flask server:
+
+```bash
+python openrouter_web.py
+```
+
+Make sure `OPENROUTER_API_KEY` is available in your environment or `.env`.
+
+Then open [http://localhost:5000](http://localhost:5000) in your browser. Type a
+message and you should see the model's reply.
+
+## Deploying to Vercel
+
+This repository is ready for deployment on [Vercel](https://vercel.com). The
+`public` directory contains the static HTML frontend and `api/chat.py` is
+deployed as a serverless function.
+
+1. Install the Vercel CLI:
+
+   ```bash
+   npm install -g vercel
+   ```
+
+2. Set the `OPENROUTER_API_KEY` environment variable in your Vercel project.
+   You can do this with `vercel env add OPENROUTER_API_KEY` or via the Vercel
+   dashboard. **Never commit your real API key.**
+
+3. Vercel automatically installs Python packages from `requirements.txt`.
+   The provided `vercel.json` configures the deployment to use Python 3.11.
+
+4. Deploy:
+
+   ```bash
+   vercel --prod
+   ```
+
+Once deployed, open your Vercel URL to chat with the AI using the hosted
+interface.

--- a/api/chat.py
+++ b/api/chat.py
@@ -1,0 +1,33 @@
+"""Serverless chat endpoint for Vercel."""
+
+from flask import Flask, request, jsonify
+
+from openrouter_chat import chat
+
+app = Flask(__name__)
+
+
+@app.post("/")
+def handle_chat() -> tuple[str, int] | tuple[dict, int]:
+    """Handle a chat request.
+
+    The function expects JSON with a ``message`` field and returns the reply
+    from the OpenRouter API.
+    """
+
+    data = request.get_json() or {}
+    message = data.get("message", "")
+    if not message:
+        return jsonify({"error": "message required"}), 400
+
+    try:
+        reply = chat([{"role": "user", "content": message}])
+    except Exception as exc:  # pragma: no cover - external call
+        app.logger.exception("Chat error")
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify({"reply": reply}), 200
+
+
+# ``app`` is picked up by Vercel's Python runtime
+handler = app

--- a/openrouter_chat.py
+++ b/openrouter_chat.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Simple CLI for chat via the OpenRouter API.
+
+The script reads ``OPENROUTER_API_KEY`` from the environment or an ``.env``
+file and uses the free Meta Llama 3 8B Instruct model by default. A system
+prompt ensures the assistant behaves as **Ruyaa**, a professional helper.
+"""
+import os
+import sys
+
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+
+API_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_MODEL = "meta-llama/llama-3-8b-instruct:free"
+DEFAULT_SYSTEM_PROMPT = (
+    "You are Ruyaa, a professional assistant. Provide clear, concise and helpful"
+    " replies."
+)
+
+# Allow overrides via environment variables
+MODEL = os.getenv("OPENROUTER_MODEL", DEFAULT_MODEL)
+SYSTEM_PROMPT = os.getenv("OPENROUTER_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT)
+
+
+def chat(messages, model=MODEL, system_prompt=SYSTEM_PROMPT):
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY environment variable not set")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if system_prompt:
+        messages = [{"role": "system", "content": system_prompt}] + messages
+
+    payload = {"model": model, "messages": messages}
+    response = requests.post(API_URL, headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    return data["choices"][0]["message"]["content"].strip()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python openrouter_chat.py 'Your message'")
+        sys.exit(1)
+
+    user_content = " ".join(sys.argv[1:])
+    messages = [{"role": "user", "content": user_content}]
+    try:
+        reply = chat(messages)
+    except Exception as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+    print(reply)
+
+
+if __name__ == "__main__":
+    main()

--- a/openrouter_web.py
+++ b/openrouter_web.py
@@ -1,0 +1,32 @@
+from flask import Flask, request, jsonify, send_file
+import os
+from openrouter_chat import chat
+
+app = Flask(__name__)
+
+
+
+HTML_PATH = os.path.join(os.path.dirname(__file__), "public", "index.html")
+
+
+@app.route("/")
+def index():
+    return send_file(HTML_PATH)
+
+
+@app.route("/api/chat", methods=["POST"])
+def api_chat():
+    data = request.get_json()
+    message = data.get("message", "") if data else ""
+    if not message:
+        return jsonify({"error": "message required"}), 400
+    try:
+        reply = chat([{"role": "user", "content": message}])
+    except Exception as exc:
+        app.logger.exception("Chat error")
+        return jsonify({"error": str(exc)}), 500
+    return jsonify({"reply": reply})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OpenRouter Chat</title>
+<style>
+body { background-color: #121212; color: #f5f5f5; font-family: Arial, sans-serif; margin:0; padding:0; }
+.chat-container { max-width: 600px; margin:40px auto; padding:20px; background-color:#1e1e1e; border-radius:8px; }
+input, button { padding:8px; border:none; border-radius:4px; }
+button { background-color:#0f62fe; color:#fff; cursor:pointer; }
+.messages { margin-top:20px; white-space:pre-wrap; }
+</style>
+</head>
+<body>
+<div class="chat-container">
+  <h1>OpenRouter Chat</h1>
+  <div>
+    <input id="message" type="text" placeholder="Say something..." style="width:80%" />
+    <button onclick="send()">Send</button>
+  </div>
+  <div id="messages" class="messages"></div>
+</div>
+<script>
+async function send() {
+  const msgInput = document.getElementById('message');
+  const text = msgInput.value;
+  if (!text) return;
+  const resp = await fetch('/api/chat', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({message:text})
+  });
+  if (!resp.ok) {
+    alert('Error: ' + resp.statusText);
+    return;
+  }
+  const data = await resp.json();
+  const messages = document.getElementById('messages');
+  messages.textContent += 'You: ' + text + '\nAI: ' + data.reply + '\n\n';
+  msgInput.value = '';
+}
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+requests
+python-dotenv

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+python3 -m pip install --upgrade pip
+pip install -r requirements.txt

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/*.py": {
+      "runtime": "python3.11"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document OPENROUTER_MODEL and OPENROUTER_SYSTEM_PROMPT variables
- allow model and prompt overrides in `openrouter_chat.py`
- provide `.env.example` for easier configuration

## Testing
- `python -m py_compile openrouter_chat.py openrouter_web.py api/chat.py`
- `./setup.sh`
- `python openrouter_web.py` *(fails: port 5000 in use)*
- `python openrouter_chat.py "Hi"` *(fails: OPENROUTER_API_KEY not set)*


------
https://chatgpt.com/codex/tasks/task_e_684ae39b01f0832eaf7fce15e1eb7446